### PR TITLE
Relax rails dependency to enable compatibility with >= 3.2.13

### DIFF
--- a/delayed-web.gemspec
+++ b/delayed-web.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files      = Dir['{app,config,lib,vendor}/**/*', 'CONTRIBUTING.md', 'LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'rails', '>= 3.2.13', '<= 5.0.0'
+  s.add_dependency 'rails', '>= 3.2.13'
 
   s.add_development_dependency 'capybara', '~> 2.1.0'
   s.add_development_dependency 'rspec-rails', '~> 2.14.2'


### PR DESCRIPTION
Relax rails dependency further, so the gemspec should not interfere with future rails updates.