### PR TITLE
fix job time format

### DIFF
--- a/app/views/delayed/web/jobs/index.html.erb
+++ b/app/views/delayed/web/jobs/index.html.erb
@@ -2,6 +2,7 @@
 
 <div class="page-header">
   <h1><%= title %></h1>
+  <h3><%= t('delayed/web.views.server_time') %> <%= l(Time.now, format: :short)%><h3>
 </div>
 
 <table class="table table-bordered">
@@ -26,8 +27,8 @@
               <%= t(job.status, scope: 'delayed/web.views.statuses').capitalize %>
             </span>
           </td>
-          <td><%= l(job.created_at, format: :short) %></td>
-          <td><%= l(job.run_at, format: :short) %></td>
+          <td style="font-size: 12px;"><%= l(job.created_at, format: :short) %></td>
+          <td style="font-size: 12px;"><%= l(job.run_at, format: :short) %></td>
           <td><%= job.attempts %></td>
           <td>
             <% if job.last_error.present? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,7 @@ en:
       run_at: Run At
       attempts: Attempts
       last_error: Last Error
+      server_time: Server Time
       handler: Handler
       actions: Actions
       buttons:
@@ -35,4 +36,4 @@ en:
 
   time:
     formats:
-      short: '%d/%m/%Y at %I.%m %p'
+      short: '%d/%m/%Y at %r'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -9,6 +9,7 @@ fr:
       run_at: Démarré le
       attempts: Essais
       last_error: Dernière Erreur
+      server_time: Heure du serveur
       handler: Gestionnaire
       actions: Actions
       queue:
@@ -35,4 +36,4 @@ fr:
 
   time:
     formats:
-      short: '%d/%m/%Y à %H:%M'
+      short: '%d/%m/%Y à %T'


### PR DESCRIPTION
The time format is wrong for en, because it uses '%m' that is for month, not minutes. Also added seconds, because there are many jobs that must be tested and synchronize in matter of seconds. As a reference I included the server time.