### PR TITLE
Compatibility with Rails 6.1

### DIFF
--- a/app/decorators/delayed/web/active_record_decorator.rb
+++ b/app/decorators/delayed/web/active_record_decorator.rb
@@ -2,7 +2,7 @@ module Delayed
   module Web
     class ActiveRecordDecorator < SimpleDelegator
       def queue! now = Time.current
-        update_attributes! run_at: now, failed_at: nil, last_error: nil
+        update! run_at: now, failed_at: nil, last_error: nil
       end
     end
   end


### PR DESCRIPTION
Minor change to make this gem compatible with Rails 6.1, as it [removed the `update_attributes` method](https://blog.saeloun.com/2019/04/15/rails-6-deprecates-update-attributes.html).